### PR TITLE
feat: add OpenTelemetry metrics and tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ futures = "0.3.32"
 
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tracing-opentelemetry = "0.33.0"
+opentelemetry = { version = "0.32.0", features = ["metrics", "trace"] }
+opentelemetry_sdk = { version = "0.32.1", features = ["metrics", "rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["http-proto", "metrics", "reqwest-client", "reqwest-rustls", "trace"] }
 
 thiserror = "2.0.18"
 

--- a/src/infra/api/auth.rs
+++ b/src/infra/api/auth.rs
@@ -1,5 +1,5 @@
 use axum::{
-    Extension, Json, Router,
+    Extension, Json, Router, middleware,
     extract::{Request, State},
     http::StatusCode,
     middleware::Next,
@@ -27,6 +27,7 @@ pub fn router(state: ApiState) -> Router<ApiState> {
     Router::new()
         .route("/signup", routing::post(sign_up))
         .route("/profile", routing::post(update).layer(auth))
+        .layer(middleware::from_fn(crate::infra::telemetry::http_middleware))
 }
 
 const ISSUER: &str = "fodinha.loty.click";

--- a/src/infra/api/game.rs
+++ b/src/infra/api/game.rs
@@ -1,14 +1,17 @@
+use std::time::Instant;
+
 use axum::{
     extract::{
         Query, State, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
+    http::StatusCode,
     response::IntoResponse,
 };
 use futures::StreamExt;
 
 use crate::{
-    infra::UserClaims,
+    infra::{UserClaims, telemetry},
     models::{
         commands::{ClientCommand, ServerMessage},
         id::{MatchId, PlayerId},
@@ -25,10 +28,15 @@ pub async fn handler(
     ws: WebSocketUpgrade,
     State(state): State<ApiState>,
     Query(query): Query<Auth>,
-) -> impl IntoResponse {
+) -> axum::response::Response {
+    let started = Instant::now();
     let claims = match get_claims_from_token(&query.token, &state.jwt_key).await {
         Ok(c) => c,
-        Err(e) => return e.into_response(),
+        Err(e) => {
+            let response = e.into_response();
+            telemetry::record_http_endpoint("GET", "/game", response.status(), started.elapsed());
+            return response;
+        }
     };
     let manager = state.manager.clone();
 
@@ -36,12 +44,19 @@ pub async fn handler(
 
     tracing::info!(">>>> {who:?} connected");
 
-    ws.on_upgrade(|socket| async move {
-        match handle_connection(socket, manager, claims).await {
-            Ok(_) => tracing::warn!(">>>> {who:?} closed normally"),
-            Err(e) => tracing::error!(">>>> {who:?} closed from error: {e}"),
-        }
-    })
+    let response = ws
+        .on_upgrade(|socket| async move {
+            match handle_connection(socket, manager, claims).await {
+                Ok(_) => tracing::warn!(">>>> {who:?} closed normally"),
+                Err(e) => tracing::error!(">>>> {who:?} closed from error: {e}"),
+            }
+        })
+        .into_response();
+    let status = response.status();
+
+    telemetry::record_http_endpoint("GET", "/game", status, started.elapsed());
+
+    response
 }
 
 async fn handle_connection(

--- a/src/infra/api/lobby.rs
+++ b/src/infra/api/lobby.rs
@@ -1,5 +1,5 @@
 use axum::{
-    Extension, Json, Router,
+    Extension, Json, Router, middleware,
     extract::{Path, State},
     routing,
 };
@@ -21,6 +21,7 @@ pub fn router() -> Router<ApiState> {
         .route("/", routing::get(get_lobbies))
         .route("/", routing::post(create_lobby))
         .route("/{id}", routing::put(join_lobby))
+        .layer(middleware::from_fn(crate::infra::telemetry::http_middleware))
 }
 
 async fn get_lobbies(State(state): State<ApiState>) -> Json<Vec<GetLobbyDto>> {

--- a/src/infra/api/stats.rs
+++ b/src/infra/api/stats.rs
@@ -1,5 +1,5 @@
 use axum::{
-    Extension, Json, Router,
+    Extension, Json, Router, middleware,
     extract::{Query, State},
     routing,
 };
@@ -17,6 +17,7 @@ pub fn router(state: ApiState) -> Router<ApiState> {
     Router::new()
         .route("/", routing::get(leaderboard))
         .route("/me", routing::get(my_stats).layer(auth))
+        .layer(middleware::from_fn(crate::infra::telemetry::http_middleware))
 }
 
 #[derive(serde::Deserialize)]

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,6 +1,7 @@
 use crate::models::id::PlayerId;
 
 pub mod api;
+pub mod telemetry;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(tag = "type", content = "data")]

--- a/src/infra/telemetry.rs
+++ b/src/infra/telemetry.rs
@@ -1,0 +1,316 @@
+use std::{
+    fmt::Display,
+    future::Future,
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+use axum::{
+    extract::{MatchedPath, Request},
+    http::{Method, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Histogram},
+    trace::TracerProvider as _,
+};
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider, trace::SdkTracerProvider};
+use tracing::Instrument;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const DEFAULT_FILTER: &str = "debug,hyper=off,rustls=error,tungstenite=error";
+
+static INSTRUMENTS: LazyLock<Instruments> = LazyLock::new(Instruments::new);
+
+struct Instruments {
+    http_requests: Counter<u64>,
+    http_request_duration: Histogram<f64>,
+    db_queries: Counter<u64>,
+    db_query_duration: Histogram<f64>,
+    actor_starts: Counter<u64>,
+    actor_start_duration: Histogram<f64>,
+    actor_messages: Counter<u64>,
+    actor_message_duration: Histogram<f64>,
+}
+
+impl Instruments {
+    fn new() -> Self {
+        let meter = global::meter(env!("CARGO_PKG_NAME"));
+
+        Self {
+            http_requests: meter
+                .u64_counter("http.server.request.count")
+                .with_description("HTTP server requests.")
+                .build(),
+            http_request_duration: meter
+                .f64_histogram("http.server.request.duration")
+                .with_unit("s")
+                .with_description("HTTP server request duration.")
+                .build(),
+            db_queries: meter
+                .u64_counter("db.client.operation.count")
+                .with_description("MongoDB client operations.")
+                .build(),
+            db_query_duration: meter
+                .f64_histogram("db.client.operation.duration")
+                .with_unit("s")
+                .with_description("MongoDB client operation duration.")
+                .build(),
+            actor_starts: meter
+                .u64_counter("actor.startup.count")
+                .with_description("Actor startups.")
+                .build(),
+            actor_start_duration: meter
+                .f64_histogram("actor.startup.duration")
+                .with_unit("s")
+                .with_description("Actor startup duration.")
+                .build(),
+            actor_messages: meter
+                .u64_counter("actor.message.count")
+                .with_description("Actor messages processed.")
+                .build(),
+            actor_message_duration: meter
+                .f64_histogram("actor.message.duration")
+                .with_unit("s")
+                .with_description("Actor message processing duration.")
+                .build(),
+        }
+    }
+}
+
+pub struct TelemetryGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = self.tracer_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            eprintln!("error shutting down OpenTelemetry tracer provider: {error}");
+        }
+
+        if let Some(provider) = self.meter_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            eprintln!("error shutting down OpenTelemetry meter provider: {error}");
+        }
+    }
+}
+
+pub fn init() -> TelemetryGuard {
+    let resource = Resource::builder()
+        .with_service_name(env!("CARGO_PKG_NAME"))
+        .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
+        .build();
+
+    let tracer_provider = otlp_configured()
+        .then(|| init_tracer_provider(resource.clone()))
+        .flatten();
+    let meter_provider = otlp_configured()
+        .then(|| init_meter_provider(resource))
+        .flatten();
+
+    let otel_layer = tracer_provider.as_ref().map(|provider| {
+        let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
+        tracing_opentelemetry::layer().with_tracer(tracer)
+    });
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from(
+            std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_FILTER.to_string()),
+        ))
+        .with(tracing_subscriber::fmt::layer().with_line_number(true))
+        .with(otel_layer)
+        .init();
+
+    TelemetryGuard {
+        tracer_provider,
+        meter_provider,
+    }
+}
+
+fn otlp_configured() -> bool {
+    [
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    ]
+    .into_iter()
+    .any(|key| std::env::var_os(key).is_some())
+}
+
+fn init_tracer_provider(resource: Resource) -> Option<SdkTracerProvider> {
+    let exporter = match opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+    {
+        Ok(exporter) => exporter,
+        Err(error) => {
+            eprintln!("failed to build OpenTelemetry span exporter: {error}");
+            return None;
+        }
+    };
+
+    let provider = SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .build();
+    global::set_tracer_provider(provider.clone());
+
+    Some(provider)
+}
+
+fn init_meter_provider(resource: Resource) -> Option<SdkMeterProvider> {
+    let exporter = match opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+    {
+        Ok(exporter) => exporter,
+        Err(error) => {
+            eprintln!("failed to build OpenTelemetry metric exporter: {error}");
+            return None;
+        }
+    };
+
+    let provider = SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_periodic_exporter(exporter)
+        .build();
+    global::set_meter_provider(provider.clone());
+
+    Some(provider)
+}
+
+pub async fn http_middleware(req: Request, next: Next) -> Response {
+    let method = req.method().clone();
+    let route = http_route(&req);
+    let path = req.uri().path().to_string();
+    let span = tracing::info_span!(
+        "http.request",
+        "otel.kind" = "server",
+        "http.request.method" = %method,
+        "http.route" = %route,
+        "url.path" = %path,
+        "http.response.status_code" = tracing::field::Empty,
+    );
+    let started = Instant::now();
+    let response = next.run(req).instrument(span.clone()).await;
+    let status = response.status();
+
+    span.record("http.response.status_code", status.as_u16() as i64);
+    record_http_request(&method, &route, status, started.elapsed());
+
+    response
+}
+
+fn http_route(req: &Request) -> String {
+    req.extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_string())
+        .unwrap_or_else(|| req.uri().path().to_string())
+}
+
+pub(crate) fn record_http_endpoint(
+    method: &'static str,
+    route: &'static str,
+    status: StatusCode,
+    duration: Duration,
+) {
+    let attrs = [
+        KeyValue::new("http.request.method", method),
+        KeyValue::new("http.route", route),
+        KeyValue::new("http.response.status_code", status.as_u16() as i64),
+    ];
+
+    INSTRUMENTS.http_requests.add(1, &attrs);
+    INSTRUMENTS
+        .http_request_duration
+        .record(duration.as_secs_f64(), &attrs);
+}
+
+fn record_http_request(method: &Method, route: &str, status: StatusCode, duration: Duration) {
+    let attrs = [
+        KeyValue::new("http.request.method", method.as_str().to_string()),
+        KeyValue::new("http.route", route.to_string()),
+        KeyValue::new("http.response.status_code", status.as_u16() as i64),
+    ];
+
+    INSTRUMENTS.http_requests.add(1, &attrs);
+    INSTRUMENTS
+        .http_request_duration
+        .record(duration.as_secs_f64(), &attrs);
+}
+
+pub(crate) async fn db_query<T, E, F>(
+    collection: &'static str,
+    operation: &'static str,
+    future: F,
+) -> Result<T, E>
+where
+    E: Display,
+    F: Future<Output = Result<T, E>>,
+{
+    let span = tracing::info_span!(
+        "db.query",
+        "db.system.name" = "mongodb",
+        "db.collection.name" = collection,
+        "db.operation.name" = operation,
+        error = tracing::field::Empty,
+    );
+    let started = Instant::now();
+    let result = future.instrument(span.clone()).await;
+    let success = result.is_ok();
+
+    span.record("error", !success);
+
+    if let Err(error) = &result {
+        let _entered = span.enter();
+        tracing::warn!(error = %error, "database query failed");
+    }
+
+    let attrs = [
+        KeyValue::new("db.system.name", "mongodb"),
+        KeyValue::new("db.collection.name", collection),
+        KeyValue::new("db.operation.name", operation),
+        KeyValue::new("success", success),
+    ];
+
+    INSTRUMENTS.db_queries.add(1, &attrs);
+    INSTRUMENTS
+        .db_query_duration
+        .record(started.elapsed().as_secs_f64(), &attrs);
+
+    result
+}
+
+pub(crate) fn record_actor_start(startup_kind: &'static str, duration: Duration, success: bool) {
+    let attrs = [
+        KeyValue::new("actor.type", "match"),
+        KeyValue::new("actor.startup.kind", startup_kind),
+        KeyValue::new("success", success),
+    ];
+
+    INSTRUMENTS.actor_starts.add(1, &attrs);
+    INSTRUMENTS
+        .actor_start_duration
+        .record(duration.as_secs_f64(), &attrs);
+}
+
+pub(crate) fn record_actor_message(message_kind: &'static str, duration: Duration) {
+    let attrs = [
+        KeyValue::new("actor.type", "match"),
+        KeyValue::new("actor.message", message_kind),
+    ];
+
+    INSTRUMENTS.actor_messages.add(1, &attrs);
+    INSTRUMENTS
+        .actor_message_duration
+        .record(duration.as_secs_f64(), &attrs);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,8 @@
 use oh_hell::{AppSettings, infra, services::manager::GameManager};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::from(
-            "debug,hyper=off,rustls=error,tungstenite=error",
-        ))
-        .with(tracing_subscriber::fmt::layer().with_line_number(true))
-        .init();
+    let _telemetry_guard = infra::telemetry::init();
 
     let settings = AppSettings::from_env().expect("to load env variables");
 

--- a/src/services/matches/manager.rs
+++ b/src/services/matches/manager.rs
@@ -1,9 +1,12 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Instant,
+};
 
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
-    infra::{AnonymousUserClaims, UserClaims},
+    infra::{AnonymousUserClaims, UserClaims, telemetry},
     models::{
         Card,
         commands::{
@@ -78,6 +81,7 @@ impl ManagerHandle {
         _player_id: PlayerId,
         settings: GameSettings,
     ) -> Result<CreateLobbyResponse, ManagerError> {
+        let started = Instant::now();
         let match_id = id::gen_matchid();
         let (tx, rx) = flume::unbounded();
 
@@ -91,6 +95,7 @@ impl ManagerHandle {
             respond,
         })
         .await;
+        telemetry::record_actor_start("new", started.elapsed(), result.is_ok());
 
         if result.is_err() {
             self.registry.remove_match(&match_id);
@@ -303,12 +308,18 @@ impl ManagerHandle {
             return;
         };
 
-        let _ = sender
-            .send_async(MatchActorMessage::DisconnectPlayer {
-                player_id,
-                outbound_tx,
-            })
-            .await;
+        let message = MatchActorMessage::DisconnectPlayer {
+            player_id,
+            outbound_tx,
+        };
+        let kind = message.kind();
+        let started = Instant::now();
+        let result = sender.send_async(message).await;
+        telemetry::record_actor_message(kind, started.elapsed());
+
+        if let Err(e) = result {
+            tracing::warn!("Error enqueueing actor disconnect message: {e}");
+        }
     }
 
     async fn hydrate_lobby_info(&self, info: LobbyInfoInternal) -> Result<LobbyInfo, ManagerError> {
@@ -381,13 +392,19 @@ impl ManagerHandle {
         build: impl FnOnce(oneshot::Sender<Result<T, ManagerError>>) -> MatchActorMessage,
     ) -> Result<T, ManagerError> {
         let (tx, rx) = oneshot::channel();
+        let message = build(tx);
+        let kind = message.kind();
+        let started = Instant::now();
 
         sender
-            .send_async(build(tx))
+            .send_async(message)
             .await
             .map_err(|_| ManagerError::ReceiverDisposed)?;
 
-        rx.await.map_err(|_| ManagerError::ReceiverDisposed)?
+        let result = rx.await.map_err(|_| ManagerError::ReceiverDisposed)?;
+        telemetry::record_actor_message(kind, started.elapsed());
+
+        result
     }
 
     async fn sender_for_player(&self, player_id: &PlayerId) -> Result<MatchSender, ManagerError> {
@@ -420,6 +437,7 @@ impl ManagerHandle {
     }
 
     async fn load_match_actor(&self, match_id: &MatchId) -> Result<MatchSender, ManagerError> {
+        let started = Instant::now();
         let metadata = self
             .repo
             .active_metadata(match_id)
@@ -429,6 +447,7 @@ impl ManagerHandle {
         let events = self.repo.load_events(match_id).await?;
 
         if events.is_empty() && metadata_status != MatchMetadataStatus::Waiting {
+            telemetry::record_actor_start("load", started.elapsed(), false);
             return Err(LobbyError::InvalidLobby.into());
         }
 
@@ -441,6 +460,7 @@ impl ManagerHandle {
 
             if let Err(e) = actor.replay_event(event.event) {
                 self.registry.remove_match(match_id);
+                telemetry::record_actor_start("load", started.elapsed(), false);
 
                 return Err(e);
             }
@@ -454,6 +474,7 @@ impl ManagerHandle {
             }
 
             self.stats_projector.notify_match_finished(match_id);
+            telemetry::record_actor_start("load", started.elapsed(), false);
 
             return Err(LobbyError::InvalidLobby.into());
         }
@@ -462,6 +483,7 @@ impl ManagerHandle {
 
         self.registry.mark_ready(match_id.clone(), tx.clone());
         tokio::spawn(actor.run(rx));
+        telemetry::record_actor_start("load", started.elapsed(), true);
 
         Ok(tx)
     }

--- a/src/services/matches/message.rs
+++ b/src/services/matches/message.rs
@@ -90,3 +90,20 @@ pub enum MatchActorMessage {
         respond: oneshot::Sender<Result<Option<GetLobbyDto>, ManagerError>>,
     },
 }
+
+impl MatchActorMessage {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::ConnectPlayer { .. } => "connect_player",
+            Self::DisconnectPlayer { .. } => "disconnect_player",
+            Self::CreateMatch { .. } => "create_match",
+            Self::JoinLobby { .. } => "join_lobby",
+            Self::StatusChange { .. } => "status_change",
+            Self::GameCommand { command, .. } => match command {
+                GameCommand::PlayTurn { .. } => "game.play_turn",
+                GameCommand::PutBid { .. } => "game.put_bid",
+            },
+            Self::GetLobbySummary { .. } => "get_lobby_summary",
+        }
+    }
+}

--- a/src/services/repositories/matches.rs
+++ b/src/services/repositories/matches.rs
@@ -4,9 +4,12 @@ use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use mongodb::{Collection, Database, bson::doc};
 
-use crate::models::{
-    game::{GameSettings, MatchEvent},
-    id::*,
+use crate::{
+    infra::telemetry,
+    models::{
+        game::{GameSettings, MatchEvent},
+        id::*,
+    },
 };
 
 #[derive(Clone)]
@@ -29,9 +32,12 @@ impl MatchesRepository {
         sequence: usize,
         event: MatchEvent,
     ) -> mongodb::error::Result<()> {
-        self.events
-            .insert_one(MatchEventDto::new(match_id, sequence, event))
-            .await?;
+        telemetry::db_query("MatchEvents", "insert_one", async {
+            self.events
+                .insert_one(MatchEventDto::new(match_id, sequence, event))
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -40,13 +46,16 @@ impl MatchesRepository {
         &self,
         match_id: &MatchId,
     ) -> mongodb::error::Result<Vec<MatchEventDto>> {
-        let cursor = self
-            .events
-            .find(doc! { "match_id": match_id.as_str() })
-            .sort(doc! { "sequence": 1 })
-            .await?;
+        telemetry::db_query("MatchEvents", "find", async {
+            let cursor = self
+                .events
+                .find(doc! { "match_id": match_id.as_str() })
+                .sort(doc! { "sequence": 1 })
+                .await?;
 
-        cursor.try_collect().await
+            cursor.try_collect().await
+        })
+        .await
     }
 
     pub async fn create_metadata(
@@ -54,9 +63,12 @@ impl MatchesRepository {
         match_id: &MatchId,
         settings: GameSettings,
     ) -> mongodb::error::Result<()> {
-        self.metadata
-            .insert_one(MatchMetadataDto::new(match_id, settings))
-            .await?;
+        telemetry::db_query("MatchMetadata", "insert_one", async {
+            self.metadata
+                .insert_one(MatchMetadataDto::new(match_id, settings))
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -66,12 +78,15 @@ impl MatchesRepository {
         match_id: &MatchId,
         player_id: &PlayerId,
     ) -> mongodb::error::Result<()> {
-        self.metadata
-            .update_one(
-                doc! { "match_id": match_id.as_str() },
-                doc! { "$addToSet": { "players": player_id.as_str() } },
-            )
-            .await?;
+        telemetry::db_query("MatchMetadata", "update_one.add_player", async {
+            self.metadata
+                .update_one(
+                    doc! { "match_id": match_id.as_str() },
+                    doc! { "$addToSet": { "players": player_id.as_str() } },
+                )
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -81,25 +96,31 @@ impl MatchesRepository {
         match_id: &MatchId,
         player_id: &PlayerId,
     ) -> mongodb::error::Result<()> {
-        self.metadata
-            .update_one(
-                doc! { "match_id": match_id.as_str() },
-                doc! {
-                    "$pull": {
-                        "players": player_id.as_str(),
-                        "ready_players": player_id.as_str(),
-                    }
-                },
-            )
-            .await?;
+        telemetry::db_query("MatchMetadata", "update_one.remove_player", async {
+            self.metadata
+                .update_one(
+                    doc! { "match_id": match_id.as_str() },
+                    doc! {
+                        "$pull": {
+                            "players": player_id.as_str(),
+                            "ready_players": player_id.as_str(),
+                        }
+                    },
+                )
+                .await
+        })
+        .await?;
 
         Ok(())
     }
 
     pub async fn delete_metadata(&self, match_id: &MatchId) -> mongodb::error::Result<()> {
-        self.metadata
-            .delete_one(doc! { "match_id": match_id.as_str() })
-            .await?;
+        telemetry::db_query("MatchMetadata", "delete_one", async {
+            self.metadata
+                .delete_one(doc! { "match_id": match_id.as_str() })
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -115,9 +136,12 @@ impl MatchesRepository {
             false => doc! { "$pull": { "ready_players": player_id.as_str() } },
         };
 
-        self.metadata
-            .update_one(doc! { "match_id": match_id.as_str() }, update)
-            .await?;
+        telemetry::db_query("MatchMetadata", "update_one.set_ready", async {
+            self.metadata
+                .update_one(doc! { "match_id": match_id.as_str() }, update)
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -136,44 +160,56 @@ impl MatchesRepository {
         &self,
         match_id: &MatchId,
     ) -> mongodb::error::Result<Option<MatchMetadataDto>> {
-        self.metadata
-            .find_one(doc! {
-                "match_id": match_id.as_str(),
-                "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
-            })
-            .await
+        telemetry::db_query("MatchMetadata", "find_one.active_by_match", async {
+            self.metadata
+                .find_one(doc! {
+                    "match_id": match_id.as_str(),
+                    "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
+                })
+                .await
+        })
+        .await
     }
 
     pub async fn active_metadata_for_player(
         &self,
         player_id: &PlayerId,
     ) -> mongodb::error::Result<Option<MatchMetadataDto>> {
-        self.metadata
-            .find_one(doc! {
-                "players": player_id.as_str(),
-                "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
-            })
-            .await
+        telemetry::db_query("MatchMetadata", "find_one.active_by_player", async {
+            self.metadata
+                .find_one(doc! {
+                    "players": player_id.as_str(),
+                    "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
+                })
+                .await
+        })
+        .await
     }
 
     pub async fn waiting_match_ids(&self) -> mongodb::error::Result<Vec<MatchId>> {
-        let cursor = self
-            .metadata
-            .find(doc! { "status": MatchMetadataStatus::Waiting.as_str() })
-            .await?;
+        let metadata: Vec<MatchMetadataDto> = telemetry::db_query("MatchMetadata", "find.waiting", async {
+            let cursor = self
+                .metadata
+                .find(doc! { "status": MatchMetadataStatus::Waiting.as_str() })
+                .await?;
 
-        let metadata: Vec<MatchMetadataDto> = cursor.try_collect().await?;
+            cursor.try_collect().await
+        })
+        .await?;
 
         Ok(metadata.into_iter().map(|m| m.match_id()).collect())
     }
 
     pub async fn finished_match_ids(&self) -> mongodb::error::Result<Vec<MatchId>> {
-        let cursor = self
-            .metadata
-            .find(doc! { "status": MatchMetadataStatus::Finished.as_str() })
-            .await?;
+        let metadata: Vec<MatchMetadataDto> = telemetry::db_query("MatchMetadata", "find.finished", async {
+            let cursor = self
+                .metadata
+                .find(doc! { "status": MatchMetadataStatus::Finished.as_str() })
+                .await?;
 
-        let metadata: Vec<MatchMetadataDto> = cursor.try_collect().await?;
+            cursor.try_collect().await
+        })
+        .await?;
 
         Ok(metadata.into_iter().map(|m| m.match_id()).collect())
     }
@@ -183,12 +219,15 @@ impl MatchesRepository {
         match_id: &MatchId,
         status: MatchMetadataStatus,
     ) -> mongodb::error::Result<()> {
-        self.metadata
-            .update_one(
-                doc! { "match_id": match_id.as_str() },
-                doc! { "$set": { "status": status.as_str() } },
-            )
-            .await?;
+        telemetry::db_query("MatchMetadata", "update_one.set_status", async {
+            self.metadata
+                .update_one(
+                    doc! { "match_id": match_id.as_str() },
+                    doc! { "$set": { "status": status.as_str() } },
+                )
+                .await
+        })
+        .await?;
 
         Ok(())
     }

--- a/src/services/repositories/stats.rs
+++ b/src/services/repositories/stats.rs
@@ -2,6 +2,7 @@ use futures::TryStreamExt;
 use mongodb::{Collection, Database, IndexModel, bson::doc};
 
 use crate::{
+    infra::telemetry,
     models::id::{MatchId, PlayerId},
     services::stats::{MatchPlayerStats, PlayerStats},
 };
@@ -23,35 +24,50 @@ impl StatsRepository {
     }
 
     pub async fn ensure_indexes(&self) -> mongodb::error::Result<()> {
-        self.match_player_stats
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "match_id": 1, "player_id": 1 })
-                    .build(),
-            )
-            .await?;
-        self.player_stats
-            .create_index(IndexModel::builder().keys(doc! { "player_id": 1 }).build())
-            .await?;
-        self.player_stats
-            .create_index(
-                IndexModel::builder()
-                    .keys(doc! { "matches_won": -1, "rounds_won": -1, "games_played": 1 })
-                    .build(),
-            )
-            .await?;
-        self.projected_matches
-            .create_index(IndexModel::builder().keys(doc! { "match_id": 1 }).build())
-            .await?;
+        telemetry::db_query("MatchPlayerStats", "create_index", async {
+            self.match_player_stats
+                .create_index(
+                    IndexModel::builder()
+                        .keys(doc! { "match_id": 1, "player_id": 1 })
+                        .build(),
+                )
+                .await
+        })
+        .await?;
+        telemetry::db_query("PlayerStats", "create_index.player_id", async {
+            self.player_stats
+                .create_index(IndexModel::builder().keys(doc! { "player_id": 1 }).build())
+                .await
+        })
+        .await?;
+        telemetry::db_query("PlayerStats", "create_index.leaderboard", async {
+            self.player_stats
+                .create_index(
+                    IndexModel::builder()
+                        .keys(doc! { "matches_won": -1, "rounds_won": -1, "games_played": 1 })
+                        .build(),
+                )
+                .await
+        })
+        .await?;
+        telemetry::db_query("StatsProjectedMatches", "create_index", async {
+            self.projected_matches
+                .create_index(IndexModel::builder().keys(doc! { "match_id": 1 }).build())
+                .await
+        })
+        .await?;
 
         Ok(())
     }
 
     pub async fn has_projected_match(&self, match_id: &MatchId) -> mongodb::error::Result<bool> {
-        self.projected_matches
-            .find_one(doc! { "match_id": match_id.as_str() })
-            .await
-            .map(|stats| stats.is_some())
+        telemetry::db_query("StatsProjectedMatches", "find_one", async {
+            self.projected_matches
+                .find_one(doc! { "match_id": match_id.as_str() })
+                .await
+        })
+        .await
+        .map(|stats| stats.is_some())
     }
 
     pub async fn mark_match_projected(&self, match_id: &MatchId) -> mongodb::error::Result<()> {
@@ -59,10 +75,13 @@ impl StatsRepository {
             match_id: match_id.as_str().to_string(),
         };
 
-        self.projected_matches
-            .replace_one(doc! { "match_id": match_id.as_str() }, &projected)
-            .upsert(true)
-            .await?;
+        telemetry::db_query("StatsProjectedMatches", "replace_one.upsert", async {
+            self.projected_matches
+                .replace_one(doc! { "match_id": match_id.as_str() }, &projected)
+                .upsert(true)
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -72,14 +91,20 @@ impl StatsRepository {
         match_id: &MatchId,
         player_id: &str,
     ) -> mongodb::error::Result<bool> {
-        self.match_player_stats
-            .find_one(doc! { "match_id": match_id.as_str(), "player_id": player_id })
-            .await
-            .map(|stats| stats.is_some())
+        telemetry::db_query("MatchPlayerStats", "find_one", async {
+            self.match_player_stats
+                .find_one(doc! { "match_id": match_id.as_str(), "player_id": player_id })
+                .await
+        })
+        .await
+        .map(|stats| stats.is_some())
     }
 
     pub async fn insert_match_stats(&self, stats: &MatchPlayerStats) -> mongodb::error::Result<()> {
-        self.match_player_stats.insert_one(stats).await?;
+        telemetry::db_query("MatchPlayerStats", "insert_one", async {
+            self.match_player_stats.insert_one(stats).await
+        })
+        .await?;
 
         Ok(())
     }
@@ -88,35 +113,46 @@ impl StatsRepository {
         &self,
         player_id: &PlayerId,
     ) -> mongodb::error::Result<Option<PlayerStats>> {
-        self.player_stats
-            .find_one(doc! { "player_id": player_id.as_str() })
-            .await
+        telemetry::db_query("PlayerStats", "find_one", async {
+            self.player_stats
+                .find_one(doc! { "player_id": player_id.as_str() })
+                .await
+        })
+        .await
     }
 
     pub async fn leaderboard(&self, limit: i64) -> mongodb::error::Result<Vec<PlayerStats>> {
-        let cursor = self
-            .player_stats
-            .find(doc! {})
-            .sort(doc! { "matches_won": -1, "rounds_won": -1, "games_played": 1 })
-            .limit(limit)
-            .await?;
+        telemetry::db_query("PlayerStats", "find.leaderboard", async {
+            let cursor = self
+                .player_stats
+                .find(doc! {})
+                .sort(doc! { "matches_won": -1, "rounds_won": -1, "games_played": 1 })
+                .limit(limit)
+                .await?;
 
-        cursor.try_collect().await
+            cursor.try_collect().await
+        })
+        .await
     }
 
     pub async fn apply_match_stats(&self, stats: &MatchPlayerStats) -> mongodb::error::Result<()> {
-        let mut aggregate = self
-            .player_stats
-            .find_one(doc! { "player_id": &stats.player_id })
-            .await?
-            .unwrap_or_else(|| PlayerStats::new(stats.player_id.clone()));
+        let mut aggregate = telemetry::db_query("PlayerStats", "find_one.apply_match_stats", async {
+            self.player_stats
+                .find_one(doc! { "player_id": &stats.player_id })
+                .await
+        })
+        .await?
+        .unwrap_or_else(|| PlayerStats::new(stats.player_id.clone()));
 
         aggregate.apply_match(stats);
 
-        self.player_stats
-            .replace_one(doc! { "player_id": &stats.player_id }, &aggregate)
-            .upsert(true)
-            .await?;
+        telemetry::db_query("PlayerStats", "replace_one.upsert", async {
+            self.player_stats
+                .replace_one(doc! { "player_id": &stats.player_id }, &aggregate)
+                .upsert(true)
+                .await
+        })
+        .await?;
 
         Ok(())
     }

--- a/src/services/repositories/users.rs
+++ b/src/services/repositories/users.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use futures::TryStreamExt;
 use mongodb::{Collection, Database, IndexModel, bson::doc};
 
-use crate::infra::UserClaims;
+use crate::infra::{UserClaims, telemetry};
 
 #[derive(Clone)]
 pub struct UsersRepository {
@@ -18,9 +18,12 @@ impl UsersRepository {
     }
 
     pub async fn ensure_indexes(&self) -> mongodb::error::Result<()> {
-        self.users
-            .create_index(IndexModel::builder().keys(doc! { "player_id": 1 }).build())
-            .await?;
+        telemetry::db_query("Users", "create_index", async {
+            self.users
+                .create_index(IndexModel::builder().keys(doc! { "player_id": 1 }).build())
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -28,19 +31,23 @@ impl UsersRepository {
     pub async fn upsert_user(&self, user: &UserClaims) -> mongodb::error::Result<()> {
         let dto = UserDto::new(user.clone());
 
-        self.users
-            .replace_one(doc! { "player_id": &dto.player_id }, &dto)
-            .upsert(true)
-            .await?;
+        telemetry::db_query("Users", "replace_one.upsert", async {
+            self.users
+                .replace_one(doc! { "player_id": &dto.player_id }, &dto)
+                .upsert(true)
+                .await
+        })
+        .await?;
 
         Ok(())
     }
 
     pub async fn user(&self, player_id: &str) -> mongodb::error::Result<Option<UserClaims>> {
-        self.users
-            .find_one(doc! { "player_id": player_id })
-            .await
-            .map(|user| user.map(|user| user.user))
+        telemetry::db_query("Users", "find_one", async {
+            self.users.find_one(doc! { "player_id": player_id }).await
+        })
+        .await
+        .map(|user| user.map(|user| user.user))
     }
 
     pub async fn users_by_id(
@@ -51,11 +58,15 @@ impl UsersRepository {
             return Ok(HashMap::new());
         }
 
-        let cursor = self
-            .users
-            .find(doc! { "player_id": { "$in": player_ids } })
-            .await?;
-        let users: Vec<UserDto> = cursor.try_collect().await?;
+        let users: Vec<UserDto> = telemetry::db_query("Users", "find.by_ids", async {
+            let cursor = self
+                .users
+                .find(doc! { "player_id": { "$in": player_ids } })
+                .await?;
+
+            cursor.try_collect().await
+        })
+        .await?;
 
         Ok(users
             .into_iter()


### PR DESCRIPTION
## Summary

Adds OpenTelemetry scaffolding and call-site instrumentation for the service boundaries:

- initializes OpenTelemetry tracing and metrics from `main`
- configures OTLP HTTP/protobuf export when OTEL env vars are present
- records HTTP endpoint metrics/traces for `/auth/*`, `/lobby/*`, `/stats/*`, and `/game`
- wraps MongoDB repository operations for matches, stats, and users
- records match actor startup timing for new and lazily restored actors
- records actor request/message timing by low-cardinality message kind
- adds local OTEL collector/env examples and docs

## Notes

I avoided rewriting `src/infra/api/mod.rs` because it contains a large integration-test module and the GitHub contents API requires whole-file updates. The sub-router endpoints are instrumented directly; only the root fallback route in that large module is not covered.

## Validation

Not run here:

- `cargo fmt`
- `cargo test`
- `cargo generate-lockfile` / `cargo check`

These need to be run locally with network access and MongoDB available.