### PR TITLE
perf: removed unnecessary db ops

### DIFF
--- a/src/infra/api/auth.rs
+++ b/src/infra/api/auth.rs
@@ -53,10 +53,6 @@ pub async fn middleware(
     let claims =
         get_claims_from_token(token, &state.jwt_key, state.google_client_id.as_deref()).await?;
 
-    if let Err(e) = state.manager.upsert_user(&claims).await {
-        tracing::error!("Error upserting authenticated user: {e}");
-    }
-
     req.extensions_mut().insert(claims);
 
     Ok(next.run(req).await)

--- a/src/infra/api/game.rs
+++ b/src/infra/api/game.rs
@@ -79,9 +79,6 @@ async fn handle_connection(
     shutdown_rx: watch::Receiver<bool>,
 ) -> Result<(), ManagerError> {
     let player_id = auth.id();
-
-    manager.upsert_user(&auth).await?;
-
     let context = manager.connect_player(player_id.clone()).await?;
 
     let connection = PlayerConnection {

--- a/src/infra/api/lobby.rs
+++ b/src/infra/api/lobby.rs
@@ -35,7 +35,7 @@ async fn join_lobby(
     Extension(user_claims): Extension<UserClaims>,
     Path(id): Path<LobbyId>,
 ) -> Result<Json<LobbyInfo>, ManagerError> {
-    let response = state.manager.join_lobby(id, user_claims).await?;
+    let response = state.manager.join_lobby(id, user_claims.id()).await?;
 
     Ok(Json(response))
 }

--- a/src/services/matches/actor.rs
+++ b/src/services/matches/actor.rs
@@ -550,13 +550,13 @@ impl MatchActor {
         let match_id = self.match_id.clone();
         let finished = self.is_finished();
 
-        tokio::spawn(async move {
-            if let Err(e) =
-                project_match_metadata(&repo, &match_id, &event, finished).await
-            {
-                tracing::error!("Error projecting match metadata: {e}");
-            }
-        });
+        if should_project_match_metadata(&event, finished) {
+            tokio::spawn(async move {
+                if let Err(e) = project_match_metadata(&repo, &match_id, &event, finished).await {
+                    tracing::error!("Error projecting match metadata: {e}");
+                }
+            });
+        }
 
         Ok(applied)
     }
@@ -829,6 +829,16 @@ impl MatchActor {
         self.player_routes.remove(player_id);
 
         Ok(())
+    }
+}
+
+fn should_project_match_metadata(event: &MatchEvent, match_finished: bool) -> bool {
+    match event {
+        MatchEvent::MatchCreated { .. }
+        | MatchEvent::PlayerJoined { .. }
+        | MatchEvent::GameStarted { .. } => true,
+        MatchEvent::TurnPlayed { .. } => match_finished,
+        MatchEvent::BidPlaced { .. } | MatchEvent::PlayerStatusChanged { .. } => false,
     }
 }
 

--- a/src/services/matches/manager.rs
+++ b/src/services/matches/manager.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::{HashMap, HashSet},
+    sync::Arc,
     time::Duration,
     time::Instant,
 };
 
 use chrono::Utc;
+use dashmap::DashMap;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
@@ -41,6 +43,7 @@ pub struct ManagerHandle {
     repo: MatchesRepository,
     stats_repo: StatsRepository,
     users_repo: UsersRepository,
+    user_cache: Arc<DashMap<PlayerId, UserClaims>>,
     stats_projector: StatsProjectorHandle,
     waiting_lobby_timeout: Duration,
 }
@@ -71,6 +74,7 @@ impl ManagerHandle {
             repo,
             stats_repo,
             users_repo,
+            user_cache: Arc::new(DashMap::new()),
             stats_projector,
             waiting_lobby_timeout,
         }
@@ -115,10 +119,8 @@ impl ManagerHandle {
     pub async fn join_lobby(
         &self,
         match_id: MatchId,
-        user_claims: UserClaims,
+        player_id: PlayerId,
     ) -> Result<LobbyInfo, ManagerError> {
-        self.users_repo.upsert_user(&user_claims).await?;
-        let player_id = user_claims.id();
         let sender = self.sender_for_match(&match_id).await?;
 
         let info = Self::request(&sender, |respond| MatchActorMessage::JoinLobby {
@@ -200,6 +202,7 @@ impl ManagerHandle {
 
     pub async fn upsert_user(&self, user: &UserClaims) -> Result<(), ManagerError> {
         self.users_repo.upsert_user(user).await?;
+        self.cache_user(user.clone());
 
         Ok(())
     }
@@ -392,11 +395,25 @@ impl ManagerHandle {
         &self,
         players: HashMap<PlayerId, LobbyPlayerStatus>,
     ) -> Result<HashMap<PlayerId, PlayerStatus>, ManagerError> {
-        let player_ids = players
-            .keys()
-            .map(|player_id| player_id.as_str().to_string())
-            .collect::<Vec<_>>();
-        let users = self.users_repo.users_by_id(&player_ids).await?;
+        let mut users = HashMap::new();
+        let mut missing = Vec::new();
+
+        for player_id in players.keys() {
+            match self.user_cache.get(player_id) {
+                Some(user) => {
+                    users.insert(player_id.as_str().to_string(), user.clone());
+                }
+                None => missing.push(player_id.as_str().to_string()),
+            }
+        }
+
+        let loaded_users = self.users_repo.users_by_id(&missing).await?;
+
+        for user in loaded_users.values() {
+            self.cache_user(user.clone());
+        }
+
+        users.extend(loaded_users);
 
         let players = players
             .into_iter()
@@ -421,10 +438,27 @@ impl ManagerHandle {
 
     async fn user_or_fallback(&self, player_id: &PlayerId) -> Result<UserClaims, ManagerError> {
         Ok(self
-            .users_repo
-            .user(player_id.as_str())
+            .cached_user(player_id)
             .await?
             .unwrap_or_else(|| fallback_user_claims(player_id)))
+    }
+
+    async fn cached_user(&self, player_id: &PlayerId) -> Result<Option<UserClaims>, ManagerError> {
+        if let Some(user) = self.user_cache.get(player_id) {
+            return Ok(Some(user.clone()));
+        }
+
+        let user = self.users_repo.user(player_id.as_str()).await?;
+
+        if let Some(user) = &user {
+            self.cache_user(user.clone());
+        }
+
+        Ok(user)
+    }
+
+    fn cache_user(&self, user: UserClaims) {
+        self.user_cache.insert(user.id(), user);
     }
 
     async fn request<T>(

--- a/src/services/repositories/matches.rs
+++ b/src/services/repositories/matches.rs
@@ -55,6 +55,24 @@ impl MatchesRepository {
         })
         .await?;
 
+        telemetry::db_query("MatchMetadata", "create_index.players_status", async {
+            self.metadata
+                .create_index(
+                    IndexModel::builder()
+                        .keys(doc! { "players": 1, "status": 1 })
+                        .build(),
+                )
+                .await
+        })
+        .await?;
+
+        telemetry::db_query("MatchMetadata", "create_index.status", async {
+            self.metadata
+                .create_index(IndexModel::builder().keys(doc! { "status": 1 }).build())
+                .await
+        })
+        .await?;
+
         Ok(())
     }
 
@@ -228,7 +246,7 @@ impl MatchesRepository {
             self.metadata
                 .find_one(doc! {
                     "match_id": match_id.as_str(),
-                    "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
+                    "status": { "$in": active_statuses() },
                 })
                 .await
         })
@@ -243,7 +261,7 @@ impl MatchesRepository {
             self.metadata
                 .find_one(doc! {
                     "players": player_id.as_str(),
-                    "status": { "$ne": MatchMetadataStatus::Finished.as_str() },
+                    "status": { "$in": active_statuses() },
                 })
                 .await
         })
@@ -373,6 +391,13 @@ pub struct MatchEventDto {
     pub match_id: Arc<str>,
     pub sequence: usize,
     pub event: MatchEvent,
+}
+
+fn active_statuses() -> Vec<&'static str> {
+    vec![
+        MatchMetadataStatus::Waiting.as_str(),
+        MatchMetadataStatus::Playing.as_str(),
+    ]
 }
 
 impl MatchEventDto {

--- a/src/services/repositories/users.rs
+++ b/src/services/repositories/users.rs
@@ -29,15 +29,15 @@ impl UsersRepository {
     }
 
     pub async fn upsert_user(&self, user: &UserClaims) -> mongodb::error::Result<()> {
-        let existing = self
-            .users
-            .find_one(doc! { "player_id": user.id().as_str() })
-            .await?;
-        let dto = UserDto::new(user.clone(), existing);
+        let player_id = user.id();
+        let user = mongodb::bson::to_bson(user)?;
 
-        telemetry::db_query("Users", "replace_one.upsert", async {
+        telemetry::db_query("Users", "update_one.upsert", async {
             self.users
-                .replace_one(doc! { "player_id": &dto.player_id }, &dto)
+                .update_one(
+                    doc! { "player_id": player_id.as_str() },
+                    doc! { "$set": { "player_id": player_id.as_str(), "user": user } },
+                )
                 .upsert(true)
                 .await
         })
@@ -84,16 +84,20 @@ impl UsersRepository {
         token: &str,
         expires_at: i64,
     ) -> mongodb::error::Result<()> {
-        let Some(mut user) = self.users.find_one(doc! { "player_id": player_id }).await? else {
-            return Ok(());
-        };
-
-        user.refresh_token = Some(token.to_string());
-        user.refresh_token_expires_at = Some(expires_at);
-
-        self.users
-            .replace_one(doc! { "player_id": player_id }, &user)
-            .await?;
+        telemetry::db_query("Users", "update_one.store_refresh_token", async {
+            self.users
+                .update_one(
+                    doc! { "player_id": player_id },
+                    doc! {
+                        "$set": {
+                            "refresh_token": token,
+                            "refresh_token_expires_at": expires_at,
+                        },
+                    },
+                )
+                .await
+        })
+        .await?;
 
         Ok(())
     }
@@ -102,7 +106,10 @@ impl UsersRepository {
         &self,
         token: &str,
     ) -> mongodb::error::Result<Option<RefreshSession>> {
-        let user = self.users.find_one(doc! { "refresh_token": token }).await?;
+        let user = telemetry::db_query("Users", "find_one.refresh_token", async {
+            self.users.find_one(doc! { "refresh_token": token }).await
+        })
+        .await?;
 
         Ok(user.and_then(|user| {
             Some(RefreshSession {
@@ -127,20 +134,4 @@ struct UserDto {
     refresh_token: Option<String>,
     #[serde(default)]
     refresh_token_expires_at: Option<i64>,
-}
-
-impl UserDto {
-    fn new(user: UserClaims, existing: Option<UserDto>) -> Self {
-        let refresh_token = existing
-            .as_ref()
-            .and_then(|user| user.refresh_token.clone());
-        let refresh_token_expires_at = existing.and_then(|user| user.refresh_token_expires_at);
-
-        Self {
-            player_id: user.id().as_str().to_string(),
-            user,
-            refresh_token,
-            refresh_token_expires_at,
-        }
-    }
 }


### PR DESCRIPTION
- Removed per-request user upserts from auth middleware.
- Removed WebSocket connection user upserts.
- Removed duplicate join_lobby user upserts.
- Added a manager-level user claim cache for lobby/snapshot hydration, so Users find.by_ids only runs for cache misses.
- Changed actual user persistence from read + replace_one.upsert to targeted update_one.upsert.
- Changed refresh-token storage from read + replace to targeted update_one.
- Kept the MatchMetadata indexes and $in active-status query fix for active_by_player.
- Kept the no-op metadata projection spawn reduction for bids/non-final turns.